### PR TITLE
Fix auth usage for agent builder

### DIFF
--- a/src/screens/Agents/AgentBuilderScreen.tsx
+++ b/src/screens/Agents/AgentBuilderScreen.tsx
@@ -14,6 +14,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../../contexts/ThemeContext';
+import { useAuth } from '../../contexts/AuthContext';
 import { Card, Button, Modal } from '../../components/ui';
 import { MotiView } from '../../components/animations';
 import { createSharedStyles } from '../../styles/shared';
@@ -43,6 +44,7 @@ interface AgentBuilderScreenProps {
 
 const AgentBuilderScreen: React.FC<AgentBuilderScreenProps> = ({ route, navigation }) => {
   const { theme } = useTheme();
+  const { userId, user } = useAuth();
   const styles = createStyles(theme);
   const sharedStyles = createSharedStyles(theme);
 
@@ -124,14 +126,16 @@ const AgentBuilderScreen: React.FC<AgentBuilderScreenProps> = ({ route, navigati
           throw new Error('Builder session not found');
         }
       } else if (route?.params?.templateId) {
+        if (!userId) throw new Error('User not authenticated');
         // Load from template
-        id = await agentBuilderService.loadTemplate(route.params.templateId, 'current_user'); // TODO: Get from auth
+        id = await agentBuilderService.loadTemplate(route.params.templateId, userId);
         const templateState = await agentBuilderService.getBuilderState(id);
         if (!templateState) throw new Error('Failed to load template');
         state = templateState;
       } else {
+        if (!userId) throw new Error('User not authenticated');
         // Initialize new builder
-        const result = await agentBuilderService.initializeBuilder('current_user'); // TODO: Get from auth
+        const result = await agentBuilderService.initializeBuilder(userId);
         state = result.state;
         id = result.builderId;
       }

--- a/src/services/agentBuilder.ts
+++ b/src/services/agentBuilder.ts
@@ -847,6 +847,7 @@ class AgentBuilderService {
       category: string;
       tags: string[];
       isPublic: boolean;
+      creatorName: string;
     }
   ): Promise<AgentTemplate> {
     const state = await this.getBuilderState(builderId);
@@ -861,7 +862,7 @@ class AgentBuilderService {
       popularity_score: 0,
       created_by: {
         id: state.config.metadata.created_by,
-        name: 'User', // TODO: Get from auth context
+        name: templateData.creatorName,
       },
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),

--- a/src/services/openaiAgentsSimple.ts
+++ b/src/services/openaiAgentsSimple.ts
@@ -53,7 +53,7 @@ class OpenAIAgentsService {
 
       // Create database record for the agent
       const databaseAgent: Omit<DatabaseAgent, 'id' | 'created_at' | 'updated_at' | 'tasks' | 'successRate'> = {
-        user_id: config.user_id || 'current_user', // Ensure user_id is provided
+        user_id: config.user_id,
         name: config.name,
         description: config.description,
         status: 'active',
@@ -70,10 +70,7 @@ class OpenAIAgentsService {
         }
       };
 
-      const savedAgent = await supabaseService.createAgent({
-        ...databaseAgent,
-        user_id: databaseAgent.user_id || 'current_user' // Ensure user_id is always string
-      });
+      const savedAgent = await supabaseService.createAgent(databaseAgent);
       if (!savedAgent) {
         throw new Error('Failed to save agent to database');
       }

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -16,6 +16,7 @@ export interface OpenAIAgentTool {
 }
 
 export interface OpenAIAgentConfig {
+  user_id?: string;
   name: string;
   description?: string;
   model?: string;


### PR DESCRIPTION
## Summary
- use `useAuth` in `AgentBuilderScreen`
- pass the user ID when initializing/loading builders
- track template creator name in `agentBuilderService`
- require a `user_id` for OpenAI agent creation

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684a9ae35b848328a1d7375850476be2