### PR TITLE
Add failure metrics to agent tests

### DIFF
--- a/src/components/agentBuilder/AgentTestingInterface.tsx
+++ b/src/components/agentBuilder/AgentTestingInterface.tsx
@@ -149,6 +149,7 @@ const AgentTestingInterface: React.FC<AgentTestingInterfaceProps> = ({
       },
       status: 'running',
       created_at: new Date().toISOString(),
+      error: undefined,
     };
 
     setCurrentConversation(newConversation);
@@ -214,6 +215,7 @@ const AgentTestingInterface: React.FC<AgentTestingInterfaceProps> = ({
             messages: testConversation.messages,
             metrics: testConversation.metrics,
             status: testConversation.status,
+            error: testConversation.error,
           });
         }
 
@@ -562,21 +564,33 @@ const AgentTestingInterface: React.FC<AgentTestingInterfaceProps> = ({
             <Text style={styles.metricLabel}>Total Tokens</Text>
           </Card>
 
-          <Card style={styles.metricCard}>
-            <LinearGradient
-              colors={[theme.colors.error + '20', theme.colors.error + '10']}
-              style={styles.metricGradient}
-            />
-            <Ionicons name="warning" size={24} color={theme.colors.error} />
-            <Text style={styles.metricValue}>{testMetrics.failed_tests}</Text>
-            <Text style={styles.metricLabel}>Failed Tests</Text>
-          </Card>
+        <Card style={styles.metricCard}>
+          <LinearGradient
+            colors={[theme.colors.error + '20', theme.colors.error + '10']}
+            style={styles.metricGradient}
+          />
+          <Ionicons name="warning" size={24} color={theme.colors.error} />
+          <Text style={styles.metricValue}>{testMetrics.failed_tests}</Text>
+          <Text style={styles.metricLabel}>Failed Tests</Text>
+        </Card>
+      </View>
+
+      {testMetrics.common_failures.length > 0 && (
+        <View style={styles.failuresSection}>
+          <Text style={styles.failureTitle}>Common Failures</Text>
+          {testMetrics.common_failures.map((f, idx) => (
+            <View key={idx} style={styles.failureItem}>
+              <Ionicons name="close-circle" size={16} color={theme.colors.error} />
+              <Text style={styles.failureText}>{f.message} ({f.count})</Text>
+            </View>
+          ))}
         </View>
-      ) : (
-        <View style={styles.noMetricsContainer}>
-          <Ionicons name="analytics-outline" size={64} color={theme.colors.textSecondary} />
-          <Text style={styles.noMetricsTitle}>No Metrics Yet</Text>
-          <Text style={styles.noMetricsDescription}>
+      )}
+    ) : (
+      <View style={styles.noMetricsContainer}>
+        <Ionicons name="analytics-outline" size={64} color={theme.colors.textSecondary} />
+        <Text style={styles.noMetricsTitle}>No Metrics Yet</Text>
+        <Text style={styles.noMetricsDescription}>
             Run some tests to see performance metrics
           </Text>
         </View>
@@ -1041,6 +1055,25 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     fontSize: 16,
     color: theme.colors.textSecondary,
     textAlign: 'center',
+  },
+  failuresSection: {
+    marginTop: 16,
+    gap: 4,
+  },
+  failureTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: theme.colors.text,
+    marginBottom: 8,
+  },
+  failureItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  failureText: {
+    fontSize: 14,
+    color: theme.colors.error,
   },
   historySection: {
     marginTop: 24,

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -233,3 +233,28 @@ export interface OpenAIAgentEvent {
   data: any;
   timestamp: string;
 }
+
+export interface AgentTestConversation {
+  id: string;
+  name: string;
+  messages: Array<{ role: 'user' | 'assistant'; content: string; timestamp: string }>;
+  metrics: {
+    response_time_ms: number;
+    tokens_used: number;
+    cost: number;
+  };
+  status: 'running' | 'completed' | 'failed';
+  error?: string;
+  created_at: string;
+}
+
+export interface AgentTestMetrics {
+  total_tests: number;
+  passed_tests: number;
+  failed_tests: number;
+  average_response_time: number;
+  average_cost_per_interaction: number;
+  total_tokens_used: number;
+  success_rate: number;
+  common_failures: Array<{ message: string; count: number }>;
+}


### PR DESCRIPTION
## Summary
- capture error messages when test conversations fail
- compute recurring failure messages in `calculateTestMetrics`
- expose new `AgentTestConversation` and `AgentTestMetrics` fields
- display common failures in the Agent Testing metrics UI

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684a9aefbcf48328a103f058bdcac003

## Summary by Sourcery

Capture and report failure metrics in agent test runs by storing error messages, aggregating common failures, extending data models, and updating the testing UI to display these insights.

New Features:
- Add an `error` field to AgentTestConversation and populate it when a test fails
- Compute and expose a `common_failures` list in AgentTestMetrics with aggregated error counts
- Persist failed test conversations immediately after errors for accurate metrics
- Render a common failures section in the Agent Testing UI showing failure messages and counts

Enhancements:
- Save error details to the preview state when tests fail for improved debugging
- Reorganize the metrics UI to conditionally display failure insights alongside existing metrics