### PR TITLE
Add tool usage tracking and metrics

### DIFF
--- a/src/screens/Analytics/AnalyticsScreen.tsx
+++ b/src/screens/Analytics/AnalyticsScreen.tsx
@@ -157,6 +157,22 @@ const AnalyticsScreen: React.FC = () => {
 
   const usageData = getUsageData();
 
+  const getToolUsageData = () => {
+    if (!analytics || !analytics.toolUsage) {
+      return [] as { name: string; population: number; color: string; legendFontColor: string; legendFontSize: number }[];
+    }
+    const colors = [theme.colors.primary, theme.colors.secondary, theme.colors.success, theme.colors.warning, theme.colors.error];
+    return analytics.toolUsage.slice(0, 5).map((item: any, idx: number) => ({
+      name: item.tool,
+      population: item.count,
+      color: colors[idx % colors.length],
+      legendFontColor: theme.colors.text,
+      legendFontSize: 12,
+    }));
+  };
+
+  const toolUsageData = getToolUsageData();
+
   const chartConfig = {
     backgroundColor: theme.colors.surface,
     backgroundGradientFrom: theme.colors.surface,
@@ -273,6 +289,27 @@ const AnalyticsScreen: React.FC = () => {
             )}
           </Card>
         </AnimatedView>
+
+        {toolUsageData.length > 0 && (
+          <AnimatedView animation="slideUp" delay={600}>
+            <Card variant="elevated" size="lg" style={styles.chartCard}>
+              <View style={styles.chartHeader}>
+                <Ionicons name="construct" size={20} color={theme.colors.primary} />
+                <Text style={styles.chartTitle}>Top Tools</Text>
+              </View>
+              <PieChart
+                data={toolUsageData}
+                width={width - 80}
+                height={220}
+                chartConfig={Platform.OS !== 'web' ? chartConfig : undefined}
+                accessor={Platform.OS !== 'web' ? 'population' : undefined}
+                backgroundColor={Platform.OS !== 'web' ? 'transparent' : undefined}
+                paddingLeft={Platform.OS !== 'web' ? '15' : undefined}
+                absolute={Platform.OS !== 'web' ? true : undefined}
+              />
+            </Card>
+          </AnimatedView>
+        )}
       </View>
     </ScrollView>
   );

--- a/src/services/enhancedAgents.ts
+++ b/src/services/enhancedAgents.ts
@@ -628,6 +628,20 @@ class EnhancedAgentsService {
       const totalCost = executions.reduce((sum, e) => sum + (e.cost || 0), 0);
       const totalTime = executions.reduce((sum, e) => sum + (e.execution_time_ms || 0), 0);
 
+      const toolCounts: Record<string, number> = {};
+      executions.forEach(e => {
+        const tools = e.metadata?.tools_used as string[] | undefined;
+        if (Array.isArray(tools)) {
+          tools.forEach(t => {
+            toolCounts[t] = (toolCounts[t] || 0) + 1;
+          });
+        }
+      });
+
+      const mostUsedTools = Object.entries(toolCounts)
+        .map(([tool, count]) => ({ tool, count }))
+        .sort((a, b) => b.count - a.count);
+
       return {
         agent_id: agentId,
         time_period: timePeriod,
@@ -638,7 +652,7 @@ class EnhancedAgentsService {
         total_tokens_used: totalTokens,
         total_cost: totalCost,
         average_cost_per_execution: totalExecutions > 0 ? totalCost / totalExecutions : 0,
-        most_used_tools: [], // TODO: Implement tool usage tracking
+        most_used_tools: mostUsedTools,
         error_rate: totalExecutions > 0 ? failedExecutions / totalExecutions : 0
       };
     } catch (error) {

--- a/src/services/openaiAgentsSimple.ts
+++ b/src/services/openaiAgentsSimple.ts
@@ -6,6 +6,9 @@ import { Agent as DatabaseAgent } from '../types';
 import { openaiModelsService } from './openaiModels';
 import { openaiAgentsSDK } from './openaiAgentsSDK';
 
+// Simple in-memory tracker for tool usage
+const toolUsageTracker: Record<string, number> = {};
+
 class OpenAIAgentsService {
   private openai: OpenAI;
   private apiKey: string;
@@ -165,17 +168,27 @@ class OpenAIAgentsService {
           max_prompt_tokens: agent.max_tokens
         });
 
+        const invokedTools: string[] = [];
         if (run.status === 'completed') {
           // Get messages
           const messages = await this.openai.beta.threads.messages.list(thread.id);
           const assistantMessages = messages.data.filter((msg: any) => msg.role === 'assistant');
-          
+
           if (assistantMessages.length > 0) {
             const lastMessage = assistantMessages[0];
             const content = lastMessage.content[0];
-            
+
             if (content.type === 'text') {
               execution.output = content.text.value;
+            }
+
+            // Track tool calls from message metadata
+            if (Array.isArray(lastMessage.tool_calls)) {
+              for (const call of lastMessage.tool_calls) {
+                const toolName = call.type === 'function' ? call.function.name : call.type;
+                invokedTools.push(toolName);
+                toolUsageTracker[toolName] = (toolUsageTracker[toolName] || 0) + 1;
+              }
             }
           }
 
@@ -193,6 +206,11 @@ class OpenAIAgentsService {
         // Clean up thread
         await this.openai.beta.threads.delete(thread.id);
 
+        // Save invoked tools in execution metadata
+        if (invokedTools.length > 0) {
+          execution.metadata = { ...execution.metadata, tools_used: invokedTools };
+        }
+
       } catch (error) {
         execution.status = 'failed';
         execution.output = `Error: ${error instanceof Error ? error.message : 'Unknown error'}`;
@@ -206,7 +224,8 @@ class OpenAIAgentsService {
         completed_at: execution.endTime,
         tokens_used: execution.tokensUsed,
         cost: execution.cost,
-        error: execution.status === 'failed' ? execution.output : null
+        error: execution.status === 'failed' ? execution.output : null,
+        metadata: execution.metadata
       });
 
       return execution;

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -225,7 +225,7 @@ export interface AgentPerformanceMetrics {
   total_tokens_used: number;
   total_cost: number;
   average_cost_per_execution: number;
-  most_used_tools: string[];
+  most_used_tools: Array<{ tool: string; count: number }>;
   error_rate: number;
   user_satisfaction_score?: number;
 }


### PR DESCRIPTION
## Summary
- log invoked tools for each execution and track counts in-memory
- expose tool counts in supabase analytics API and agent metrics
- display top tools chart on analytics screen
- update AgentPerformanceMetrics type

## Testing
- `npx eslint .` *(fails: ESLint couldn't find a config)*
- `node test-openai-agents-sdk.js`
- `node test_database.js` *(fails: Cannot find module '@supabase/supabase-js')*
- `node test-agent-execution.js`
- `node test-sdk-integration.js`


------
https://chatgpt.com/codex/tasks/task_b_684a9af10a008328be6fe0237bc7ce73