### PR TITLE
Update collaboration scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,23 @@ npx expo prebuild
 - Cost analysis
 - System health monitoring
 
+### Agent Collaboration Metrics
+The application computes a **collaboration score** for each agent based on:
+
+1. **Step success rate** – how often an agent's steps succeed
+2. **Average response time** – how quickly the agent completes a step
+3. **Contribution to workflow steps** – the proportion of steps performed by the agent
+
+Each factor is weighted (`success 50%`, `response time 30%`, `contribution 20%`) to
+produce a 0‑100 score:
+
+```
+score = (successRate * 0.5 + (1 - normalizedResponseTime) * 0.3 + contribution * 0.2) * 100
+```
+
+Team collaboration efficiency is then the weighted average of all agent scores
+based on their executed steps.
+
 ## Contributing
 
 1. Fork the repository


### PR DESCRIPTION
## Summary
- compute collaboration scores from success rate, response time and step contribution
- average those scores by executed steps for overall collaboration efficiency
- document the formula in README

## Testing
- `node test-openai-agents-sdk.js`
- `npx tsc --noEmit` *(fails: expo/tsconfig.base not found)*

------
https://chatgpt.com/codex/tasks/task_b_684aa8e6d9fc8328b2934779c890840b

## Summary by Sourcery

Implement a proper collaboration scoring system for agents, update the team efficiency calculation to weight by execution counts, and add documentation of the scoring formulas in the README.

New Features:
- Compute agent collaboration scores using weighted metrics of success rate, response time, and workflow contribution

Enhancements:
- Replace placeholder random scores with a deterministic 0–100 formula
- Update overall team collaboration efficiency to use a weighted average based on executed steps

Documentation:
- Document the collaboration scoring formula and contributing metrics in the README