### PR TITLE
Fix metrics view and use chart-kit fork

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ This is an Expo React Native app that mirrors KB-Atlas web features for mobile. 
 - Database: `@supabase/supabase-js`
 - OpenAI Agents: `@openai/agents` for AI agent creation and execution
 - Navigation: `@react-navigation/*` (stack, bottom-tabs, drawer)
-- Charts: `react-native-chart-kit`, `victory-native`
+- Charts: `react-native-chart-kit-chz`, `victory-native`
 - UI: `@expo/vector-icons`, `react-native-vector-icons`
 - Animations: `react-native-reanimated`, `react-native-gesture-handler`, `moti`, `lottie-react-native`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "react-dom": "19.0.0",
         "react-is": "^19.1.0",
         "react-native": "0.79.3",
-        "react-native-chart-kit": "^6.12.0",
+        "react-native-chart-kit-chz": "^1.1.2",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-reanimated": "~3.17.4",
@@ -14790,10 +14790,10 @@
         "prop-types": "^15.8.1"
       }
     },
-    "node_modules/react-native-chart-kit": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/react-native-chart-kit/-/react-native-chart-kit-6.12.0.tgz",
-      "integrity": "sha512-nZLGyCFzZ7zmX0KjYeeSV1HKuPhl1wOMlTAqa0JhlyW62qV/1ZPXHgT8o9s8mkFaGxdqbspOeuaa6I9jUQDgnA==",
+    "node_modules/react-native-chart-kit-chz": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/react-native-chart-kit-chz/-/react-native-chart-kit-chz-1.1.2.tgz",
+      "integrity": "sha512-MIrN+zB6B6oRpQiMMNFc13JUO2c+hJ1ytY1/6V2vNhbbX6YsJhBKt3vnDnN/SUXOc6Bx/6CkXbkqVKgf/mBlAw==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dom": "19.0.0",
     "react-is": "^19.1.0",
     "react-native": "0.79.3",
-    "react-native-chart-kit": "^6.12.0",
+    "react-native-chart-kit-chz": "^1.1.2",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-reanimated": "~3.17.4",

--- a/src/components/agentBuilder/AgentTestingInterface.tsx
+++ b/src/components/agentBuilder/AgentTestingInterface.tsx
@@ -507,6 +507,7 @@ const AgentTestingInterface: React.FC<AgentTestingInterfaceProps> = ({
       </Text>
 
       {testMetrics ? (
+        <>
         <View style={styles.metricsGrid}>
           <Card style={styles.metricCard}>
             <LinearGradient
@@ -573,20 +574,21 @@ const AgentTestingInterface: React.FC<AgentTestingInterfaceProps> = ({
           <Text style={styles.metricValue}>{testMetrics.failed_tests}</Text>
           <Text style={styles.metricLabel}>Failed Tests</Text>
         </Card>
-      </View>
-
-      {testMetrics.common_failures.length > 0 && (
-        <View style={styles.failuresSection}>
-          <Text style={styles.failureTitle}>Common Failures</Text>
-          {testMetrics.common_failures.map((f, idx) => (
-            <View key={idx} style={styles.failureItem}>
-              <Ionicons name="close-circle" size={16} color={theme.colors.error} />
-              <Text style={styles.failureText}>{f.message} ({f.count})</Text>
-            </View>
-          ))}
         </View>
-      )}
-    ) : (
+
+        {testMetrics.common_failures.length > 0 && (
+          <View style={styles.failuresSection}>
+            <Text style={styles.failureTitle}>Common Failures</Text>
+            {testMetrics.common_failures.map((f, idx) => (
+              <View key={idx} style={styles.failureItem}>
+                <Ionicons name="close-circle" size={16} color={theme.colors.error} />
+                <Text style={styles.failureText}>{f.message} ({f.count})</Text>
+              </View>
+            ))}
+          </View>
+        )}
+        </>
+      ) : (
       <View style={styles.noMetricsContainer}>
         <Ionicons name="analytics-outline" size={64} color={theme.colors.textSecondary} />
         <Text style={styles.noMetricsTitle}>No Metrics Yet</Text>

--- a/src/components/charts/WebChart.tsx
+++ b/src/components/charts/WebChart.tsx
@@ -29,7 +29,7 @@ const WebChart: React.FC<WebChartProps> = ({ title, width: chartWidth, height = 
         {title || 'Chart'} (Web Preview)
       </Text>
       <Text style={{ color: theme.colors.textSecondary, fontSize: 12, marginTop: 8 }}>
-        Charts will be rendered with react-native-chart-kit in native apps
+        Charts will be rendered with react-native-chart-kit-chz in native apps
       </Text>
     </View>
   );

--- a/src/screens/Analytics/AnalyticsScreen.tsx
+++ b/src/screens/Analytics/AnalyticsScreen.tsx
@@ -14,7 +14,7 @@ if (Platform.OS === 'web') {
   const WebChart = require('../../components/charts/WebChart').default;
   PieChart = WebChart;
 } else {
-  const ChartKit = require('react-native-chart-kit');
+  const ChartKit = require('react-native-chart-kit-chz');
   PieChart = ChartKit.PieChart;
 }
 

--- a/src/screens/Dashboard/DashboardScreen.tsx
+++ b/src/screens/Dashboard/DashboardScreen.tsx
@@ -21,7 +21,7 @@ if (Platform.OS === 'web') {
   LineChart = WebChart;
   BarChart = WebChart;
 } else {
-  const ChartKit = require('react-native-chart-kit');
+  const ChartKit = require('react-native-chart-kit-chz');
   LineChart = ChartKit.LineChart;
   BarChart = ChartKit.BarChart;
 }


### PR DESCRIPTION
## Summary
- fix JSX syntax in metrics tab
- swap to `react-native-chart-kit-chz` for long-term maintenance
- update docs to mention new chart-kit fork

## Testing
- `npm run lint -- --quiet` *(fails: Missing script)*
- `node test_database.js` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_684aa8ebbc8c8328bbb4f46835f5c71a